### PR TITLE
Não limpa conteúdo da memoria

### DIFF
--- a/src/Horse.Etag.pas
+++ b/src/Horse.Etag.pas
@@ -54,7 +54,7 @@ begin
     if (Req.Headers['If-None-Match'] = eTag) and (eTag <> '') then
     begin
       Res.Status(THTTPStatus.NotModified);
-      Res.Content(nil);
+      Res.RawWebResponse.Content := '';
     end;
 
     Res.RawWebResponse.SetCustomHeader('ETag', eTag);


### PR DESCRIPTION
Ao realizar teste com comando Res.Content(nil);  notei que aplicativo não libera memoria da requisição fazendo com que consumo de memoria só aumente  podendo levar a um estouro de memoria.